### PR TITLE
change response type from Ox to String

### DIFF
--- a/lib/shanon/authenticatable.rb
+++ b/lib/shanon/authenticatable.rb
@@ -1,7 +1,8 @@
 module Shanon
   module Authenticatable
     def get_token
-      @token = Shanon::Clients::AuthenticationClient.new.get
+      xml = Shanon::Clients::AuthenticationClient.new.get
+      @token = ::Ox.parse(xml).Response.Token.text
     end
   end
 end

--- a/lib/shanon/clients/authentication_client.rb
+++ b/lib/shanon/clients/authentication_client.rb
@@ -6,13 +6,7 @@ module Shanon
       def get
         params = params_with_signature(password: secrets[:password])
         response = conn.get(PATH, params)
-        parse(response.body)
-      end
-
-      private
-
-      def parse(xml)
-        ::Ox.parse(xml).Response.Token.text
+        response.body
       end
     end
   end

--- a/lib/shanon/clients/enquete_client.rb
+++ b/lib/shanon/clients/enquete_client.rb
@@ -9,13 +9,7 @@ module Shanon
       def get(opts={})
         params = params_with_signature(opts)
         response = conn.get PATH, params
-        parse(response.body)
-      end
-
-      private
-
-      def parse(xml)
-        ::Ox.parse(xml)
+        response.body
       end
     end
   end

--- a/lib/shanon/clients/visitor_client.rb
+++ b/lib/shanon/clients/visitor_client.rb
@@ -13,13 +13,7 @@ module Shanon
       def get(opts={})
         params = params_with_signature(opts)
         response = conn.get PATH, params
-        parse(response.body)
-      end
-
-      private
-
-      def parse(xml)
-        ::Ox.parse(xml)
+        response.body
       end
     end
   end

--- a/test/clients/authentication_client_test.rb
+++ b/test/clients/authentication_client_test.rb
@@ -9,6 +9,6 @@ class AuthenticationClientTest < BaseClientTest
   end
 
   test 'should return token' do
-    assert_equal @dummy_token, @client.get
+    assert { @client.get.include?(@dummy_token) }
   end
 end


### PR DESCRIPTION
- Every client should return simple `XML` by `String`
- before: return `Ox::Object`
- after: return `String`